### PR TITLE
converted to python3, and fixed some small errors (removed password requirement)

### DIFF
--- a/ted_fetch.py
+++ b/ted_fetch.py
@@ -9,6 +9,8 @@ from jnpr.junos import Device
 from lxml import etree
 import argparse, logging, getpass, sys
 
+import json
+import pprint
 
 def main(args):
 
@@ -16,19 +18,41 @@ def main(args):
     user = args.user
     # no password as we're relying on local ssh keys
 
+    ted = None
+    js = ""
+
     # setup our connection
-    dev=Device(host=host, user=user, password=password)
+    dev=Device(host=host, user=user)
     try:
         dev.open()
 
         # retrieve TED
         ted = dev.rpc.get_ted_database_information({'format': 'json'})
 
+
+        print("=== raw response ===")
         print(ted)
+        print()
+    except Exception as e:
+        print ("Failed to retreive TED: {}".format(e))
+    
+    # convert ted to valid json string
+    json_str = str(ted).replace("'",'"')
 
-    except:
-        print "Failed to retreive TED"
+    print("=== json_str ===")
+    print(json_str)
+    print()
 
+    # converts the json string to a dictionary object (load the json into the correct types of Python variables, recursively, effectively.
+    js = json.loads(json_str)
+
+    print("=== json in python dict ===")
+    print(js)
+    print()
+
+    # optional easy-to read recursive dict/list (json too?) printing
+    print("=== python dict pretty printing ===")
+    pprint.pprint(js)
 
 # execute only if called directly (not as a module)
 if __name__ == "__main__":


### PR DESCRIPTION
Converted code to Python3. Mostly, just the print statement with no `()`'s.

Some type conversions may not be necessary, but they are the correct types at the end.

I also broke out the Exception from the catch so that it's more verbose. Sure, the error is not caught specifically but with a very generic catch clause, but it does the trick.

Converts to a (probably RFC) valid JSON format, and then loads that into a Python dictionary in a relatively easy to use and sensible format.

Notes:
* not best code quality ever
* may cause problems with strings that contain a double quote in them naturally, as it will convert it to a double quote. One can add a thing that escapes these properly? Not sure how json handles that in the RFC's.